### PR TITLE
Add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,86 @@
+name: 🐛 Bug Report
+description: Report a bug or unexpected behavior with the MUTHUR Terminal
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill out the information below to help us investigate.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+      placeholder: Describe what went wrong...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this issue?
+      placeholder: |
+        1. Go to '...'
+        2. Type '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected Area
+      description: Which part of the application is affected?
+      options:
+        - Boot Sequence
+        - Terminal / Chat Interface
+        - AI Responses (MUTHUR persona)
+        - CRT Visual Effects
+        - API / Backend
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser
+      description: Which browser are you using?
+      placeholder: e.g. Chrome 120, Firefox 121, Safari 17
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      description: Which OS are you on?
+      placeholder: e.g. Windows 11, macOS Sonoma, Ubuntu 22.04
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain the issue.
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other information that might be relevant.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,54 @@
+name: ✨ Feature Request
+description: Suggest a new feature or enhancement for the MUTHUR Terminal
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea to improve the MUTHUR Terminal? We'd love to hear it.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or Motivation
+      description: What problem does this feature solve? Is this related to a frustration?
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like to see.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Have you considered any alternative solutions or workarounds?
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Feature Area
+      description: Which part of the application does this relate to?
+      options:
+        - Boot Sequence
+        - Terminal / Chat Interface
+        - AI Responses (MUTHUR persona)
+        - CRT Visual Effects
+        - API / Backend
+        - Deployment / Infrastructure
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any mockups, screenshots, or references that help illustrate the idea.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,37 @@
+## Description
+
+<!-- Provide a brief summary of the changes in this PR. -->
+
+## Type of Change
+
+<!-- Check the relevant options. -->
+
+- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
+- [ ] ✨ New feature (non-breaking change that adds functionality)
+- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] 📝 Documentation update
+- [ ] 🎨 Style / UI change
+- [ ] ♻️ Refactor (no functional changes)
+- [ ] 🔧 Configuration / infrastructure change
+
+## Related Issues
+
+<!-- Link any related issues. Use "Closes #123" to auto-close. -->
+
+## Testing
+
+<!-- Describe how you tested these changes. -->
+
+- [ ] Tested locally with `npm run dev`
+- [ ] Verified boot sequence works correctly
+- [ ] Verified terminal chat interface works correctly
+- [ ] Verified CRT visual effects render properly
+- [ ] No console errors in browser dev tools
+
+## Screenshots
+
+<!-- If applicable, add screenshots showing the changes. -->
+
+## Additional Notes
+
+<!-- Any other context or notes for reviewers. -->


### PR DESCRIPTION
## Summary

Adds standard GitHub issue templates and a pull request template to streamline contributions.

## Changes

- **Bug Report template** (\.github/ISSUE_TEMPLATE/bug-report.yml\) — YAML issue form with fields for description, repro steps, expected/actual behavior, affected area, browser, OS, and screenshots
- **Feature Request template** (\.github/ISSUE_TEMPLATE/feature-request.yml\) — YAML issue form with fields for problem/motivation, proposed solution, alternatives, and feature area
- **Template config** (\.github/ISSUE_TEMPLATE/config.yml\) — Enables blank issues for anything that doesn't fit the templates
- **PR template** (\.github/pull_request_template.md\) — Checklist covering change type, related issues, testing steps, and screenshots