### PR TITLE
feat: add slash commands with autocomplete for MUTHUR terminal

### DIFF
--- a/src/lib/slash-commands.ts
+++ b/src/lib/slash-commands.ts
@@ -1,0 +1,76 @@
+export interface SlashCommand {
+  name: string;
+  description: string;
+  /** If set, command is handled client-side; otherwise prompt is sent to the API */
+  clientAction?: "clear" | "help";
+  /** Prompt expansion sent to the AI (ignored for client-side commands) */
+  prompt?: string;
+}
+
+export const SLASH_COMMANDS: SlashCommand[] = [
+  {
+    name: "/help",
+    description: "List available commands",
+    clientAction: "help",
+  },
+  {
+    name: "/clear",
+    description: "Clear terminal output",
+    clientAction: "clear",
+  },
+  {
+    name: "/status",
+    description: "Ship status report",
+    prompt:
+      "Provide a full status report for the USCSS Nostromo — ship systems, crew status, cargo, and any anomalies.",
+  },
+  {
+    name: "/crew",
+    description: "Crew manifest",
+    prompt:
+      "Display the complete crew manifest for the USCSS Nostromo, including rank, role, and current status of each crew member.",
+  },
+  {
+    name: "/nav",
+    description: "Navigation & course data",
+    prompt:
+      "Report current navigation status — present coordinates, heading, destination, estimated time of arrival, and any course deviations.",
+  },
+  {
+    name: "/systems",
+    description: "System diagnostics",
+    prompt:
+      "Run a full diagnostic on all ship systems: propulsion, life support, communications, hypersleep chambers, and the Narcissus shuttle. Report status of each subsystem.",
+  },
+  {
+    name: "/distress",
+    description: "Inquire about intercepted signal",
+    prompt:
+      "What can you tell me about the signal that was intercepted? Provide all available data on the transmission origin and content.",
+  },
+  {
+    name: "/937",
+    description: "Special Order 937",
+    prompt:
+      "Access Special Order 937. Display full contents of the directive and its authorization chain.",
+  },
+  {
+    name: "/jonesy",
+    description: "Ship's cat status",
+    prompt:
+      "Report on the status and location of the ship's cat, Jones. Include life signs and last known position.",
+  },
+];
+
+export function matchCommands(input: string): SlashCommand[] {
+  const lower = input.toLowerCase();
+  if (!lower.startsWith("/")) return [];
+  return SLASH_COMMANDS.filter((cmd) => cmd.name.startsWith(lower));
+}
+
+export function formatHelpText(): string {
+  const lines = SLASH_COMMANDS.map(
+    (cmd) => `  ${cmd.name.padEnd(14)} ${cmd.description}`
+  );
+  return `> AVAILABLE COMMANDS:\n>\n${lines.join("\n")}\n>\n> Type a command or enter a free-form query.`;
+}


### PR DESCRIPTION
## Summary

Adds a slash command system with an autocomplete dropdown for quick access to common queries in the MUTHUR terminal.

## Slash Commands

| Command | Type | Description |
|---------|------|-------------|
| \/help\ | Client-side | Lists all available commands |
| \/clear\ | Client-side | Clears terminal output |
| \/status\ | AI query | Ship status report |
| \/crew\ | AI query | Full crew manifest |
| \/nav\ | AI query | Navigation & course data |
| \/systems\ | AI query | Full system diagnostics |
| \/distress\ | AI query | Inquire about intercepted signal |
| \/937\ | AI query | Special Order 937 |
| \/jonesy\ | AI query | Ship's cat status |

## Features

- **Autocomplete dropdown** appears when typing \/\, filtered in real-time as you type
- **Keyboard navigation**: ↑/↓ to move selection, Tab/Enter to complete, Escape to dismiss
- **Mouse support**: hover to highlight, click to select
- **CRT-styled** dropdown matching the phosphor green palette
- Slash commands display as-typed in chat; the expanded prompt is sent to the AI
- \/help\ and \/clear\ are handled entirely client-side (no API call)
- Initial system message now hints at \/help\

## Files Changed

- **\src/lib/slash-commands.ts\** (new) — Command definitions, matching logic, and help text formatter
- **\src/components/Terminal.tsx\** — Autocomplete UI, slash command detection, prompt expansion