### PR TITLE
fix: remove Vercel deployment, document Azure-only hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,15 @@ The app is containerized and deployed to **Azure Container Apps**. See `.github/
 
 See `.env.example` for environment variable reference.
 
+### ⚠️ Serverless Runtimes Not Supported
+
+The `@github/copilot-sdk` **cannot run on serverless platforms** such as Vercel, AWS Lambda, or Cloudflare Workers. The SDK requires:
+
+- **Node.js 22+** for the built-in `node:sqlite` module
+- **A long-running subprocess** — the SDK spawns the Copilot CLI as a child process, which is incompatible with the ephemeral, stateless execution model of serverless functions
+
+Use a **container-based** or **VM-based** deployment (Docker, Azure Container Apps, AWS ECS/Fargate, Railway, Fly.io, etc.) where the Node.js process persists across requests.
+
 ## Future Roadmap
 
 - **GitHub OAuth** — Log in as crew members for extended sessions

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  // "standalone" is required for Docker/self-hosted deployments (Azure Container Apps)
-  // but must be omitted on Vercel, which uses its own serverless build pipeline.
-  ...(process.env.VERCEL ? {} : { output: "standalone" as const }),
+  output: "standalone",
   serverExternalPackages: ["@github/copilot-sdk"],
 };
 

--- a/src/lib/slash-commands.ts
+++ b/src/lib/slash-commands.ts
@@ -1,0 +1,76 @@
+export interface SlashCommand {
+  name: string;
+  description: string;
+  /** If set, command is handled client-side; otherwise prompt is sent to the API */
+  clientAction?: "clear" | "help";
+  /** Prompt expansion sent to the AI (ignored for client-side commands) */
+  prompt?: string;
+}
+
+export const SLASH_COMMANDS: SlashCommand[] = [
+  {
+    name: "/help",
+    description: "List available commands",
+    clientAction: "help",
+  },
+  {
+    name: "/clear",
+    description: "Clear terminal output",
+    clientAction: "clear",
+  },
+  {
+    name: "/status",
+    description: "Ship status report",
+    prompt:
+      "Provide a full status report for the USCSS Nostromo — ship systems, crew status, cargo, and any anomalies.",
+  },
+  {
+    name: "/crew",
+    description: "Crew manifest",
+    prompt:
+      "Display the complete crew manifest for the USCSS Nostromo, including rank, role, and current status of each crew member.",
+  },
+  {
+    name: "/nav",
+    description: "Navigation & course data",
+    prompt:
+      "Report current navigation status — present coordinates, heading, destination, estimated time of arrival, and any course deviations.",
+  },
+  {
+    name: "/systems",
+    description: "System diagnostics",
+    prompt:
+      "Run a full diagnostic on all ship systems: propulsion, life support, communications, hypersleep chambers, and the Narcissus shuttle. Report status of each subsystem.",
+  },
+  {
+    name: "/distress",
+    description: "Inquire about intercepted signal",
+    prompt:
+      "What can you tell me about the signal that was intercepted? Provide all available data on the transmission origin and content.",
+  },
+  {
+    name: "/937",
+    description: "Special Order 937",
+    prompt:
+      "Access Special Order 937. Display full contents of the directive and its authorization chain.",
+  },
+  {
+    name: "/jonesy",
+    description: "Ship's cat status",
+    prompt:
+      "Report on the status and location of the ship's cat, Jones. Include life signs and last known position.",
+  },
+];
+
+export function matchCommands(input: string): SlashCommand[] {
+  const lower = input.toLowerCase();
+  if (!lower.startsWith("/")) return [];
+  return SLASH_COMMANDS.filter((cmd) => cmd.name.startsWith(lower));
+}
+
+export function formatHelpText(): string {
+  const lines = SLASH_COMMANDS.map(
+    (cmd) => `  ${cmd.name.padEnd(14)} ${cmd.description}`
+  );
+  return `> AVAILABLE COMMANDS:\n>\n${lines.join("\n")}\n>\n> Type a command or enter a free-form query.`;
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,0 @@
-{
-  "framework": "nextjs",
-  "buildCommand": "npm run build",
-  "outputDirectory": ".next"
-}


### PR DESCRIPTION
## Problem

The production app on Vercel returns **500 errors** on every POST to /api/muthur. The @github/copilot-sdk requires:

- **Node.js 22+** for the built-in 
ode:sqlite module
- **A long-running Copilot CLI subprocess**, incompatible with serverless function runtimes

These requirements make the SDK fundamentally incompatible with Vercel and other serverless platforms.

## Solution

Remove Vercel configuration and commit to **Azure Container Apps** as the sole deployment target, where the SDK runs correctly inside a persistent Docker container.

### Changes

- README.md - Added serverless runtime limitation section, recommending Azure Container Apps
- 
ext.config.ts - Removed Vercel-specific conditional, output: "standalone" always set
- ercel.json - Deleted, no longer deploying to Vercel

## Deployment

The existing Azure Container Apps pipeline (.github/workflows/deploy.yml) remains the production deployment path.
