### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,7 @@ jobs:
   # ── Job 1: Determine target environment ──
   resolve-env:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       environment: ${{ steps.set.outputs.environment }}
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/The-weyland-yutani-corporation/MUTHUR-TERMINAL/security/code-scanning/1](https://github.com/The-weyland-yutani-corporation/MUTHUR-TERMINAL/security/code-scanning/1)

Add an explicit `permissions` block for the job that currently lacks one (`resolve-env`), setting minimal permissions. Since this job only computes an output and does not require repository access, the safest least-privilege setting is:

```yml
permissions: {}
```

This prevents inherited broad defaults and satisfies the CodeQL rule without altering workflow functionality.

**Where to change:** `.github/workflows/deploy.yml`, under `jobs.resolve-env` (after `runs-on` is a good spot).

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
